### PR TITLE
Add per-layer flags to StackedStore

### DIFF
--- a/common.go
+++ b/common.go
@@ -105,6 +105,9 @@ func Open(locator string) (Store, error) {
 // storage needs.  Each Store (including ones created with MakeSub()
 // should operate as seperate, flat key/value stores.
 type Store interface {
+	sync.Locker
+	RLock()
+	RUnlock()
 	// Open opens the store for use.
 	Open(Codec) error
 	// GetSub fetches an already-existing substore.  nil means there is no such substore.
@@ -136,6 +139,8 @@ type Store interface {
 	// Close closes the store.  Attempting to perfrom operations on
 	// a closed store will panic.
 	Close()
+	// Closed returns whether or not a store is Closed
+	Closed() bool
 	// Type is the type of Store this is.
 	Type() string
 }
@@ -264,6 +269,10 @@ func (s *storeBase) Parent() Store {
 	defer s.RUnlock()
 	s.panicIfClosed()
 	return s.parentStore.(Store)
+}
+
+func (s *storeBase) Closed() bool {
+	return !s.opened
 }
 
 func (s *storeBase) setParent(p Store) {

--- a/stack.go
+++ b/stack.go
@@ -232,6 +232,14 @@ func (s *StackedStore) Load(key string, val interface{}) error {
 func (s *StackedStore) Save(key string, val interface{}) error {
 	s.RLock()
 	defer s.RUnlock()
+	idx, ok := s.keys[key]
+	if ok && idx != 0 {
+		// Key already exists.  Can it be overridden?
+		if s.storeFlags[idx].keysCannotBeOverridden ||
+			s.storeFlags[0].keysCannotOverride {
+			return UnWritable(key)
+		}
+	}
 	err := s.stores[0].Save(key, val)
 	if err == nil {
 		s.keys[key] = 0

--- a/stack.go
+++ b/stack.go
@@ -1,13 +1,30 @@
 package store
 
+import (
+	"fmt"
+	"strings"
+)
+
+type layerFlags struct {
+	// Test to see if layers from n-1..0 have the same key.  If they do,
+	// then the keys will override this one, violating the stack sanity
+	// checking rules.
+	keysCannotBeOverridden bool
+	// Test to see if layers from n+1..len(stack) have this key.  If
+	// they do, then this key will override that key, violating the
+	// stack sanity checking rules.
+	keysCannotOverride bool
+}
+
 // StackedStore is a store that represents the combination of several
 // stores stacked together.  The first store in the stack is the only
 // one that is writable, and the rest are set as read-only.
 // StackedStores are initally created empty.
 type StackedStore struct {
 	storeBase
-	stores []Store
-	keys   map[string]int
+	stores     []Store
+	storeFlags []layerFlags
+	keys       map[string]int
 }
 
 func (s *StackedStore) Type() string {
@@ -17,6 +34,7 @@ func (s *StackedStore) Type() string {
 func (s *StackedStore) Open(codec Codec) error {
 	s.Codec = codec
 	s.stores = []Store{}
+	s.storeFlags = []layerFlags{}
 	s.keys = map[string]int{}
 	s.opened = true
 	s.closer = func() {
@@ -27,58 +45,115 @@ func (s *StackedStore) Open(codec Codec) error {
 	return nil
 }
 
-// Push adds a Store to the stack of stores in this stack.  Any Store
-// but the inital one will be marked as read-only.
-func (s *StackedStore) Push(stores ...Store) error {
-	if len(stores) == 0 {
-		return nil
+type pushTracker struct {
+	*StackedStore
+	newLayer     Store
+	newLayerKeys []string
+	err          error
+	newSub       bool
+	pushing      bool
+	subTrackers  map[string]*pushTracker
+}
+
+func (pt *pushTracker) unlock() {
+	for _, v := range pt.subTrackers {
+		v.unlock()
 	}
+	pt.newLayer.RUnlock()
+	if len(pt.stores) > 1 && pt.pushing {
+		pt.newLayer.SetReadOnly()
+	}
+	pt.Unlock()
+}
+
+func (pt *pushTracker) push(kCBO, kCO bool) {
+	pt.pushing = true
+	for k, st := range pt.subTrackers {
+		st.push(kCBO, kCO)
+		if st.newSub {
+			addSub(pt.StackedStore, st.StackedStore, k)
+		}
+	}
+	newFlags := layerFlags{
+		keysCannotBeOverridden: kCBO,
+		keysCannotOverride:     kCO,
+	}
+	pt.storeFlags = append(pt.storeFlags, newFlags)
+	pt.stores = append(pt.stores, pt.newLayer)
+	for _, key := range pt.newLayerKeys {
+		if _, ok := pt.keys[key]; !ok {
+			pt.keys[key] = len(pt.stores) - 1
+		}
+	}
+}
+
+func (s *StackedStore) pushOK(layer Store, kCBO, kCO bool) (res *pushTracker) {
 	s.Lock()
-	defer s.Unlock()
+	layer.RLock()
 	s.panicIfClosed()
-	oldLen := len(s.stores)
-	s.stores = append(s.stores, stores...)
-	// Cache the top store for quick access
-	for i := oldLen; i == len(s.stores); i++ {
-		if i > 0 {
-			s.stores[i].SetReadOnly()
+	if layer.Closed() {
+		panic("Cannot push a closed store")
+	}
+	res = &pushTracker{
+		StackedStore: s,
+		newLayer:     layer,
+		subTrackers:  map[string]*pushTracker{},
+	}
+	res.newLayerKeys, res.err = layer.Keys()
+	if res.err != nil {
+		return
+	}
+	badKeys := []string{}
+	for _, k := range res.newLayerKeys {
+		i, ok := s.keys[k]
+		if !ok {
+			// New key.  Cannot be overridden, and nothing else would override it that should not.
+			continue
+		}
+		if kCBO {
+			badKeys = append(badKeys,
+				fmt.Sprintf("keysCannotBeOverridden: %s is already in layer %d", k, i))
+		}
+		if s.storeFlags[i].keysCannotOverride {
+			badKeys = append(badKeys,
+				fmt.Sprintf("keysCannotOverride: %s would be overridden by layer %d", k, i))
 		}
 	}
-	// Update the key mappings
-	subStacks := map[string][]Store{}
-	for i, item := range stores {
-		newKeys, err := item.Keys()
-		if err != nil {
-			return err
-		}
-		for _, k := range newKeys {
-			if _, ok := s.keys[k]; !ok {
-				s.keys[k] = i + oldLen
-			}
-		}
-		for k, v := range item.Subs() {
-			if _, ok := subStacks[k]; !ok {
-				subStacks[k] = []Store{v}
-			} else {
-				subStacks[k] = append(subStacks[k], v)
-			}
-		}
+	if len(badKeys) != 0 {
+		res.err = fmt.Errorf("New layer violates key restrictions: %s", strings.Join(badKeys, "\n\t"))
+		return
 	}
-	// Update or create new subs as needed.
-	for k, v := range subStacks {
-		var sub *StackedStore
-		if obj, ok := s.subStores[k]; !ok {
-			sub = &StackedStore{}
-			sub.Open(s.Codec)
+	for k, v := range layer.Subs() {
+		var subPT *pushTracker
+		if subStore, ok := s.subStores[k]; !ok {
+			newStore := &StackedStore{}
+			newStore.Open(s.Codec)
+			subPT = newStore.pushOK(v, kCBO, kCO)
+			subPT.newSub = true
 		} else {
-			sub = obj.(*StackedStore)
+			subPT = subStore.(*StackedStore).pushOK(v, kCBO, kCO)
 		}
-		if err := sub.Push(v...); err != nil {
-			return err
+		res.subTrackers[k] = subPT
+		if subPT.err != nil {
+			res.err = subPT.err
+			return
 		}
-		sub.closer = nil
-		addSub(s, sub, k)
 	}
+	return
+}
+
+// Push adds a Store to the stack of stores in this stack.  Any Store
+// but the inital one will be marked as read-only.  Either the Push
+// call succeeds, or nothing about any of the Stores that are part of
+// the Push operation change and the error contains details about what
+// went wrong.
+func (s *StackedStore) Push(layer Store, keysCannotBeOverridden, keysCannotOverride bool) error {
+	tracker := s.pushOK(layer, keysCannotBeOverridden, keysCannotOverride)
+	defer tracker.unlock()
+	if tracker.err != nil {
+		return tracker.err
+	}
+	tracker.push(keysCannotBeOverridden, keysCannotOverride)
 	return nil
 }
 
@@ -90,7 +165,6 @@ func (s *StackedStore) Layers() []Store {
 	return res
 }
 
-// MakeSub on a StackedStore is not allowed.
 func (s *StackedStore) MakeSub(st string) (Store, error) {
 	s.Lock()
 	defer s.Unlock()
@@ -99,6 +173,8 @@ func (s *StackedStore) MakeSub(st string) (Store, error) {
 	var err error
 	if sub, ok := s.subStores[st]; ok {
 		mySub = sub.(*StackedStore)
+		mySub.Lock()
+		defer mySub.Unlock()
 	}
 	sub := s.stores[0].GetSub(st)
 	if sub != nil && mySub != nil {
@@ -110,23 +186,25 @@ func (s *StackedStore) MakeSub(st string) (Store, error) {
 			return nil, err
 		}
 	}
-	if mySub == nil {
-		mySub = &StackedStore{}
-		mySub.Open(s.Codec)
-		if err := mySub.Push(sub); err != nil {
-			return nil, err
-		}
-		addSub(s, mySub, st)
-		return mySub, nil
-	}
-	subStores := []Store{sub}
-	subStores = append(subStores, mySub.stores...)
 	newSub := &StackedStore{}
 	newSub.Open(s.Codec)
-	if err := newSub.Push(subStores...); err != nil {
+	err = newSub.Push(sub,
+		s.storeFlags[0].keysCannotBeOverridden,
+		s.storeFlags[0].keysCannotOverride)
+	if err != nil {
 		return nil, err
 	}
-	mySub.opened = false
+	if mySub != nil {
+		for i, sub := range mySub.stores {
+			subStore := sub.(*StackedStore)
+			kCBO := subStore.storeFlags[i].keysCannotBeOverridden
+			kCO := subStore.storeFlags[i].keysCannotOverride
+			if err := newSub.Push(subStore, kCBO, kCO); err != nil {
+				return nil, err
+			}
+		}
+		mySub.opened = false
+	}
 	addSub(s, newSub, st)
 	return newSub, nil
 }

--- a/stack_test.go
+++ b/stack_test.go
@@ -1,0 +1,160 @@
+package store
+
+import (
+	"fmt"
+	"testing"
+)
+
+func mks(s ...Store) []Store {
+	return s
+}
+
+func makeStack(t *testing.T, stacks []Store, fail bool, flags ...bool) *StackedStore {
+	st := &StackedStore{}
+	st.Open(nil)
+	var err error
+	for i, sub := range stacks {
+		bCNO := false
+		bCO := false
+		flagI := i << 1
+		if flagI < len(flags) {
+			bCNO = flags[flagI]
+			if flagI+1 < len(flags) {
+				bCO = flags[flagI+1]
+			}
+		}
+		if err != nil {
+			continue
+		}
+		if sub == nil {
+			sub, _ = Open("memory://")
+		}
+		err = st.Push(sub, bCNO, bCO)
+	}
+	if err == nil {
+		if fail {
+			t.Errorf("Expected to fail creating stack, but didn't")
+		}
+		return st
+	}
+	if fail {
+		t.Logf("Got expected error creating stack: %v", err)
+	} else {
+		t.Errorf("Expected to create stack, but failed with %v", err)
+	}
+	return nil
+}
+
+func checkErr(t *testing.T, ref, err error) {
+	refType, errType := fmt.Sprintf("%T", ref), fmt.Sprintf("%T", err)
+	if refType == errType {
+		t.Logf("Got expected error %s: %v", refType, err)
+	} else {
+		t.Errorf("Unexpected error %s: %v", refType, err)
+	}
+}
+
+func TestStackSimple(t *testing.T) {
+	tobj := struct{ Foo, Bar string }{"foo", "bar"}
+	var tgt interface{}
+	s2, _ := Open("memory://")
+	s2.Save("foo", &tobj)
+	sub, _ := s2.MakeSub("sub1")
+	s2.MakeSub("sub2")
+	sub.Save("foo", &tobj)
+	s3, _ := Open("memory://")
+	s3.Save("bar", &tobj)
+	s3.MakeSub("sub2")
+	st := makeStack(t, mks(nil, s2, s3), false,
+		false, true,
+		true, true,
+		false, false)
+	if st == nil {
+		return
+	}
+	checkErr(t, StackCannotOverride(""), st.Save("bar", &tobj))
+	checkErr(t, StackCannotBeOverridden(""), st.Save("foo", &tobj))
+	checkErr(t, nil, st.Save("baz", &tobj))
+	checkErr(t, nil, st.Remove("baz"))
+	checkErr(t, NotFound(""), st.Remove("baz"))
+	checkErr(t, UnWritable(""), st.Remove("foo"))
+	checkErr(t, UnWritable(""), st.Remove("bar"))
+	sub, err := st.MakeSub("sub1")
+	checkErr(t, nil, err)
+	checkErr(t, nil, sub.Load("foo", &tgt))
+	checkErr(t, UnWritable(""), sub.Remove("foo"))
+	_, err = st.MakeSub("sub3")
+	checkErr(t, nil, err)
+	st.Close()
+}
+
+func TestStackCannotBeOverridden(t *testing.T) {
+	tobj := struct{ Foo, Bar string }{"foo", "bar"}
+	s1, _ := Open("memory://")
+	s1.Save("foo", &tobj)
+	s1.MakeSub("sub1")
+	s2, _ := Open("memory://")
+	s2.Save("foo", &tobj)
+	s2.MakeSub("sub1")
+	st := makeStack(t, mks(s1, s2), true,
+		false, false,
+		true, false)
+	if st != nil {
+		t.Errorf("Expected stack creation to fail, it passed!")
+	} else {
+		t.Logf("Stack creation failed, as expected.")
+	}
+}
+
+func TestSubStackCannotBeOverridden(t *testing.T) {
+	tobj := struct{ Foo, Bar string }{"foo", "bar"}
+	s1, _ := Open("memory://")
+	sub1, _ := s1.MakeSub("sub1")
+	sub1.Save("foo", &tobj)
+	s2, _ := Open("memory://")
+	sub2, _ := s2.MakeSub("sub1")
+	sub2.Save("foo", &tobj)
+	st := makeStack(t, mks(s1, s2), true,
+		false, false,
+		true, false)
+	if st != nil {
+		t.Errorf("Expected stack creation to fail, it passed!")
+	} else {
+		t.Logf("Stack creation failed, as expected.")
+	}
+}
+
+func TestStackCannotOverride(t *testing.T) {
+	tobj := struct{ Foo, Bar string }{"foo", "bar"}
+	s1, _ := Open("memory://")
+	s1.Save("foo", &tobj)
+	s1.MakeSub("sub1")
+	s2, _ := Open("memory://")
+	s2.Save("foo", &tobj)
+	s2.MakeSub("sub1")
+	st := makeStack(t, mks(s1, s2), true,
+		false, true,
+		false, false)
+	if st != nil {
+		t.Errorf("Expected stack creation to fail, it passed!")
+	} else {
+		t.Logf("Stack creation failed, as expected.")
+	}
+}
+func TestSubStackCannotOverride(t *testing.T) {
+	tobj := struct{ Foo, Bar string }{"foo", "bar"}
+	s1, _ := Open("memory://")
+	sub1, _ := s1.MakeSub("sub1")
+	sub1.Save("foo", &tobj)
+	s2, _ := Open("memory://")
+	sub2, _ := s2.MakeSub("sub1")
+	sub2.Save("foo", &tobj)
+	st := makeStack(t, mks(s1, s2), true,
+		false, true,
+		false, false)
+	if st != nil {
+		t.Errorf("Expected stack creation to fail, it passed!")
+	} else {
+		t.Logf("Stack creation failed, as expected.")
+	}
+}


### PR DESCRIPTION
These allow you to set whether you want to allow keys at a certain
layer of the stack to to override keys at a lower layer of the stack
or whether you want to restrict keys at a certain layer of the stack
from being overridden by higher layers of the stack.